### PR TITLE
Use the maven_artifact module to download Jolokia

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       ANSIBLE_PYTHON_INTERPRETER: /usr/bin/python3
 
     steps:
-      - run: sudo rm /etc/apt/sources.list.d/google.list /etc/apt/sources.list.d/heroku.list
+      - run: sudo rm -f /etc/apt/sources.list.d/google.list /etc/apt/sources.list.d/heroku.list
       - run: sudo apt remove --assume-yes --purge apparmor
       - run: sudo apt update
       - run: sudo apt install tree
@@ -27,6 +27,9 @@ jobs:
       - checkout
       - run: printf '[defaults]\nroles_path=../' > ansible.cfg
       - run: ansible-lint
+
+      # dependencies
+      - run: ansible-galaxy collection install community.general
 
       - run: ansible-playbook tests/test.yml -i tests/inventory --connection=local -v
       - run: ansible-playbook tests/test.yml -i tests/inventory --connection=local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,3 +42,4 @@ jobs:
       - run: while ! sudo -u mcs screen -list mcs; do sleep 1; done
       - run: sudo -u mcs screen -p 0 -S mcs -X eval 'stuff "version"\015'
       - run: tail /home/mcs/server/logs/latest.log
+      - run: sudo systemctl stop mcs

--- a/README.md
+++ b/README.md
@@ -12,9 +12,22 @@ Plugin installation as well as server configuration is currently out-of-scope.
 
 ## Installation
 
+### Requirements
+
+In your `requirements.yml`:
+
+```yaml
+roles:
+  - src: simplyvanilla.mcs
+    version: main
+
+collections:
+  - name: community.general
+```
+
 ### Role Variables
 
-```
+```yaml
 # Minecraft release to install
 mcs_version: '1.18.2'
 
@@ -37,10 +50,11 @@ _none_
 
 ### Example Playbook
 
-```
+```yaml
 - hosts: servers
-  roles:
-    - src: simplyvanilla.mcs
+  tasks:
+    - ansible.builtin.import_role:
+        name: simplyvanilla.mcs
 ```
 
 ## Usage

--- a/tasks/o11y.yml
+++ b/tasks/o11y.yml
@@ -12,4 +12,5 @@
     artifact_id: jolokia-jvm
     version: "{{ mcs_jolokia_version }}"
     dest: /opt/jolokia/jolokia-jvm-{{ mcs_jolokia_version }}.jar
+    mode: '0644'
   become: yes

--- a/tasks/o11y.yml
+++ b/tasks/o11y.yml
@@ -7,7 +7,9 @@
   become: yes
 
 - name: fetch jolokia agent
-  ansible.builtin.get_url:
-    url: https://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/{{ mcs_jolokia_version }}/jolokia-jvm-{{ mcs_jolokia_version }}.jar
+  community.general.maven_artifact:
+    group_id: org.jolokia
+    artifact_id: jolokia-jvm
+    version: "{{ mcs_jolokia_version }}"
     dest: /opt/jolokia/jolokia-jvm-{{ mcs_jolokia_version }}.jar
   become: yes

--- a/tasks/pre.yml
+++ b/tasks/pre.yml
@@ -4,6 +4,7 @@
   ansible.builtin.apt:
     name:
       - acl
+      - python3-lxml
     state: present
     update_cache: yes
     cache_valid_time: 3600


### PR DESCRIPTION
Ansible already has a module for downloading artefacts from Maven Central. This can be used in-place of trying to find the Jolokia Agent Jar using Maven's API